### PR TITLE
New class syntax & static rendering

### DIFF
--- a/examples/index.js
+++ b/examples/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {render} from 'react-dom';
-import MalarkeyComponent from 'react-malarkey';
+import Malarkey from 'react-malarkey';
 
 const messages = [
   'JavaScript Professionals',
@@ -8,6 +8,6 @@ const messages = [
 ];
 
 render(
-  <MalarkeyComponent messages={messages} />,
+  <Malarkey messages={messages} />,
   document.getElementById('root')
 );

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import malarkey from 'malarkey';
 
+// TODO: Use ES2016 properties when possible https://github.com/yannickcr/eslint-plugin-react/issues/43#issuecomment-93952239
+// or maybe even functional component syntax
 export default class Malarkey extends React.Component {
   constructor (props) {
     super(props);

--- a/index.js
+++ b/index.js
@@ -1,30 +1,37 @@
 import React from 'react';
 import malarkey from 'malarkey';
 
-const MalarkeyComponent = React.createClass({
-  getDefaultProps () {
-    return {
-      messages: [],
-      options: {
-        loop: true
-      },
-      sequence (m, messages) {
-        messages.forEach(message => {
-          m.type(message).pause().delete();
-        });
-      }
-    };
-  },
+export default class Malarkey extends React.Component {
+  constructor (props) {
+    super(props);
+  }
 
   componentDidMount () {
     const {messages, options, sequence} = this.props;
     const m = malarkey(this.node, options);
     sequence(m, messages);
-  },
+  }
 
   render () {
-    return <div ref={node => this.node = node} />;
+    const {messages, staticRender} = this.props;
+    if (staticRender) {
+      // return a random message on static rendering
+      return <span>{ messages[Math.floor(Math.random() * messages.length)] }</span>;
+    }
+    return <span ref={node => this.node = node} />;
   }
-});
+}
 
-export default MalarkeyComponent;
+Malarkey.displayName = 'Malarkey';
+Malarkey.defaultProps = {
+  messages: [],
+  options: {
+    loop: true
+  },
+  sequence (m, messages) {
+    messages.forEach(message => {
+      m.type(message).pause().delete();
+    });
+  },
+  staticRender: false
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-malarkey",
   "version": "1.0.0",
-  "description": "React component for malarkey",
+  "description": "Malarkey as a React component",
   "main": "index.js",
   "scripts": {
     "test": "BABEL_ENV=test mocha --compilers js:babel-register",
@@ -22,9 +22,11 @@
     "url": "https://github.com/karlhorky/react-malarkey/issues"
   },
   "homepage": "https://github.com/karlhorky/react-malarkey#readme",
+  "dependencies": {
+    "malarkey": "^1.3.3"
+  },
   "peerDependencies": {
-    "malarkey": "^1.3.2",
-    "react": "^0.14.5"
+      "react": "^0.14.6"
   },
   "devDependencies": {
     "babel": "^6.3.26",
@@ -40,9 +42,9 @@
     "eslint": "^1.10.3",
     "eslint-plugin-react": "^3.11.3",
     "mocha": "^2.3.4",
-    "react": "^0.14.5",
-    "react-addons-test-utils": "^0.14.5",
-    "react-dom": "^0.14.5",
+    "react": "^0.14.6",
+    "react-addons-test-utils": "^0.14.6",
+    "react-dom": "^0.14.6",
     "webpack": "^1.12.9",
     "webpack-dev-server": "^1.14.0"
   }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "malarkey": "^1.3.3"
   },
   "peerDependencies": {
-      "react": "^0.14.6"
+    "react": "^0.14.6"
   },
   "devDependencies": {
     "babel": "^6.3.26",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,33 +1,39 @@
 'use strict';
 
 import React from 'react';
-import MalarkeyComponent from '../index';
+import Malarkey from '../index';
 import {shallow, describeWithDOM, mount, spyLifecycle} from 'enzyme';
 
 import {expect} from 'chai';
 
 describe('MalarkeyComponent', () => {
-  it('should render one <div />', () => {
-    const wrapper = shallow(<MalarkeyComponent />);
-    expect(wrapper.find('div')).to.have.length(1);
+  it('should render one <span />', () => {
+    const wrapper = shallow(<Malarkey />);
+    expect(wrapper.find('span')).to.have.length(1);
   });
 });
 
 describeWithDOM('MalarkeyComponent DOM', () => {
   it('should mount', () => {
-    spyLifecycle(MalarkeyComponent);
-    mount(<MalarkeyComponent />);
-    expect(MalarkeyComponent.prototype.componentDidMount.calledOnce).to.be.true;
+    spyLifecycle(Malarkey);
+    mount(<Malarkey />);
+    expect(Malarkey.prototype.componentDidMount.calledOnce).to.be.true;
   });
 
   it('should render text from props', () => {
     const messages = ['a', 'b'];
-    const wrapper = mount(<MalarkeyComponent messages={messages} />);
+    const wrapper = mount(<Malarkey messages={messages} />);
     const promise = new Promise(resolve => {
       setTimeout(() => { return resolve(wrapper.text()); }, 60);
     });
     return promise.then(message => {
       expect(message).to.equal(messages[0]);
     });
+  });
+
+  it('should render static markup', () => {
+    const messages = ['a'];
+    const wrapper = mount(<Malarkey messages={messages} staticRender={true} />);
+    expect(wrapper.text()).to.equal(messages[0]);
   });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -6,14 +6,14 @@ import {shallow, describeWithDOM, mount, spyLifecycle} from 'enzyme';
 
 import {expect} from 'chai';
 
-describe('MalarkeyComponent', () => {
+describe('Malarkey', () => {
   it('should render one <span />', () => {
     const wrapper = shallow(<Malarkey />);
     expect(wrapper.find('span')).to.have.length(1);
   });
 });
 
-describeWithDOM('MalarkeyComponent DOM', () => {
+describeWithDOM('Malarkey DOM', () => {
   it('should mount', () => {
     spyLifecycle(Malarkey);
     mount(<Malarkey />);


### PR DESCRIPTION
- refactored to fit the new react component ES2015 class syntax
- added prop `staticRender` to be used for static rendering
- Updated dependencies and split them. Malarkey is now a dependency.
- Component now renders a `<span />` instead of a `<div />` because it is most likely used in inline elements such as `<h1 />`
